### PR TITLE
V0.87.11

### DIFF
--- a/aider/__init__.py
+++ b/aider/__init__.py
@@ -1,6 +1,6 @@
 from packaging import version
 
-__version__ = "0.87.10.dev"
+__version__ = "0.87.11.dev"
 safe_version = __version__
 
 try:

--- a/aider/models.py
+++ b/aider/models.py
@@ -8,7 +8,6 @@ import platform
 import sys
 import time
 from dataclasses import dataclass, fields
-from datetime import datetime
 from pathlib import Path
 from typing import Optional, Union
 
@@ -903,57 +902,6 @@ class Model(ModelSettings):
     def is_ollama(self):
         return self.name.startswith("ollama/") or self.name.startswith("ollama_chat/")
 
-    def github_copilot_token_to_open_ai_key(self, extra_headers):
-        # check to see if there's an openai api key
-        # If so, check to see if it's expire
-        openai_api_key = "OPENAI_API_KEY"
-
-        if openai_api_key not in os.environ or (
-            int(dict(x.split("=") for x in os.environ[openai_api_key].split(";"))["exp"])
-            < int(datetime.now().timestamp())
-        ):
-            import requests
-
-            class GitHubCopilotTokenError(Exception):
-                """Custom exception for GitHub Copilot token-related errors."""
-
-                pass
-
-            # Validate GitHub Copilot token exists
-            if "GITHUB_COPILOT_TOKEN" not in os.environ:
-                raise KeyError("GITHUB_COPILOT_TOKEN environment variable not found")
-
-            github_token = os.environ["GITHUB_COPILOT_TOKEN"]
-            if not github_token.strip():
-                raise KeyError("GITHUB_COPILOT_TOKEN environment variable is empty")
-
-            headers = {
-                "Authorization": f"Bearer {os.environ['GITHUB_COPILOT_TOKEN']}",
-                "Editor-Version": extra_headers["Editor-Version"],
-                "Copilot-Integration-Id": extra_headers["Copilot-Integration-Id"],
-                "Content-Type": "application/json",
-            }
-
-            url = "https://api.github.com/copilot_internal/v2/token"
-            res = requests.get(url, headers=headers)
-            if res.status_code != 200:
-                safe_headers = {k: v for k, v in headers.items() if k != "Authorization"}
-                token_preview = github_token[:5] + "..." if len(github_token) >= 5 else github_token
-                safe_headers["Authorization"] = f"Bearer {token_preview}"
-                raise GitHubCopilotTokenError(
-                    f"GitHub Copilot API request failed (Status: {res.status_code})\n"
-                    f"URL: {url}\n"
-                    f"Headers: {json.dumps(safe_headers, indent=2)}\n"
-                    f"JSON: {res.text}"
-                )
-
-            response_data = res.json()
-            token = response_data.get("token")
-            if not token:
-                raise GitHubCopilotTokenError("Response missing 'token' field")
-
-            os.environ[openai_api_key] = token
-
     def send_completion(
         self, messages, functions, stream, temperature=None, tools=None, max_tokens=None
     ):
@@ -1028,8 +976,6 @@ class Model(ModelSettings):
                     "Editor-Version": f"aider/{__version__}",
                     "Copilot-Integration-Id": "vscode-chat",
                 }
-
-            self.github_copilot_token_to_open_ai_key(kwargs["extra_headers"])
 
         try:
             res = litellm.completion(**kwargs)

--- a/aider/resources/model-metadata.json
+++ b/aider/resources/model-metadata.json
@@ -1,6 +1,6 @@
 {
     "deepseek/deepseek-reasoner": {
-        "max_tokens": 64000,
+        "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
         "input_cost_per_token": 0.00000028,
@@ -15,9 +15,9 @@
         "supports_prompt_caching": true
     },
     "deepseek/deepseek-chat": {
-        "max_tokens": 8192,
+        "max_tokens": 128000,
         "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
+        "max_output_tokens": 8000,
         "input_cost_per_token": 0.00000028,
         "input_cost_per_token_cache_hit": 0.000000028,
         "cache_read_input_token_cost": 0.000000028,


### PR DESCRIPTION
Actually address:
#30 
#34 

My bad, didn't update the output token limits and removed the GITHUB_COPILOT_TOKEN/OPEN_API_TOKEN pre checks from models.py that prevent litellm from fully handling the github_copilot authentication process